### PR TITLE
Skipped non existing at['path']

### DIFF
--- a/export.py
+++ b/export.py
@@ -108,6 +108,9 @@ def save_attachments(config, hashes, id, msg):
             continue
 
         name = 'signal-{}.{}'.format(sent.strftime('%Y-%m-%d-%H%M%S'), ext)
+        if not at.get("path"):
+            logger.warning('Skipping %s (path does not exist)', at.get('id'))
+            continue
         src = os.path.join(config['signalDir'], 'attachments.noindex', at['path'])
         dst = os.path.join(config['outputDir'], sender, name)
         if not os.path.exists(src):


### PR DESCRIPTION
I got the following traceback when trying to use your awesome script:
```
Traceback (most recent call last):                                                                                                                                                                       
  File "export.py", line 191, in <module>                                                                                                                                                                
    msg_stats = save_attachments(config, hashes, *msg)                                                                                                                                                   
  File "export.py", line 111, in save_attachments                                                                                                                                                        
    src = os.path.join(config['signalDir'], 'attachments.noindex', at['path'])                                                                                                                           
KeyError: 'path' 
```
For some reason I had around 10 `at` variables with non existing `path`  key, so I added a condition to skip them in case it happens.