### PR TITLE
Specify libsqlcipher version + install tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Requirements
 
 ### libsqlcipher
 
-`libsqlcipher` must be installed on your system prior to installation of `pysqlcipher`, so that the binary extension module can be compiled. Consult your operating system documentation for how to install SQL Cipher. You can also manually build SQL Cipher by cloning [sqlcipher](https://github.com/sqlcipher/sqlcipher) and following the build instructions.
+`libsqlcipher>=3.30` must be installed on your system prior to installation of `pysqlcipher`, so that the binary extension module can be compiled. Consult your operating system documentation for how to install SQL Cipher. You can also manually build SQL Cipher by cloning [sqlcipher](https://github.com/sqlcipher/sqlcipher) and following the build instructions, followed by `sudo make install && sudo ldconfig`.
 
-For Arch Linux, you can install the [sqlcipher](https://www.archlinux.org/packages/community/x86_64/sqlcipher/) package. For Debian, there is a [libsqlcipher-dev](https://packages.debian.org/stable/libsqlcipher-dev) package.
+For Arch Linux, you can install the [sqlcipher](https://www.archlinux.org/packages/community/x86_64/sqlcipher/) package. For Debian, there is a (currently outdated) [libsqlcipher-dev](https://packages.debian.org/stable/libsqlcipher-dev) package.
 
 ### Python (>=3.6)
 


### PR DESCRIPTION
[This comment](https://unix.stackexchange.com/questions/505008/signal-desktop-how-to-export-messages#comment1062262_505009) says you need `libsqlcipher>=3.30`. For my part it didn't work with Ubuntu's provided `3.4.1` but it worked with the `4.3.0` I compiled from source.